### PR TITLE
Change teams score data type to integer

### DIFF
--- a/db/migrate/20140201035011_change_data_type_for_team_score.rb
+++ b/db/migrate/20140201035011_change_data_type_for_team_score.rb
@@ -1,0 +1,13 @@
+class ChangeDataTypeForTeamScore < ActiveRecord::Migration
+  def self.up
+    change_table :teams do |t|
+      t.change :score, :integer
+    end
+  end
+
+  def self.down
+    change_table :teams do |t|
+      t.change :score, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140123031700) do
+ActiveRecord::Schema.define(version: 20140201035011) do
 
   create_table "achievements", force: true do |t|
     t.string   "name"
@@ -72,7 +72,7 @@ ActiveRecord::Schema.define(version: 20140123031700) do
     t.integer  "num_players",             default: 2,     null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "score",                   default: "0",   null: false
+    t.integer  "score",                   default: 0,     null: false
     t.boolean  "won",                     default: false, null: false
   end
 


### PR DESCRIPTION
Somewhere, somehow, team score got changed to be a string instead of an integer. This was resulting in the error when trying to score a goal:

``` ruby
TypeError at /games/3/score
===========================

> no implicit conversion of Fixnum into String

app/models/score.rb, line 19
----------------------------
   14     #
   15     def add_score
   16       transaction do
   17         self.player.points = self.player.points + 1
   18         if self.player.save
>  19           self.player.team.score = self.player.team.score + 1
   20           self.player.team.save
   21         end
   22         self.player.inc_score_stats
   23       end
   24     end
```

This change adds a new migration that updates the team.score type from string to integer.
