### PR TITLE
fix #7: unscore button

### DIFF
--- a/app/assets/stylesheets/common.css.sass
+++ b/app/assets/stylesheets/common.css.sass
@@ -26,6 +26,8 @@ img.avatar:hover
   margin: auto
   text-align: center
 
+.score-controls
+  margin-right: 10px
 
 .copyright
   float: right

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -32,8 +32,10 @@ class Player < ActiveRecord::Base
   # Takes away a point from the player
   #
   def unscore
-    s = Score.for_player(self).first
+    s = Score.for_player(self).last
+
     if s
+      s.player = self
       return false unless s.destroy
     end
     s

--- a/app/views/games/in_progress.html.haml
+++ b/app/views/games/in_progress.html.haml
@@ -31,7 +31,7 @@
               %div{:class => 'clearfix player '+(p.top_scorer? ? 'top-scorer' : '')}
                 .score-controls
                   = link_to 'Score', game_score_path(@game,{:player_id => p.id }), :class => 'pull-left btn btn-score btn-primary', :remote => true, :method => :post
-                  = link_to 'Unscore', game_unscore_path(@game,{:player_id => p.id }), :class => 'pull-left btn btn-score btn-primary disabled', :remote => true, :method => :post
+                  = link_to 'Unscore', game_unscore_path(@game,{:player_id => p.id }), :class => 'pull-left btn btn-unscore btn-default', :remote => true, :method => :post
                 .player-meta
                   %span{class: 'position'}= p.position.capitalize.to_s+' - '
                   = link_to p.user.name, p.user


### PR DESCRIPTION
- Removes the disabled state from the unscore button ILO of the default button state. 
- Adds some margin to the right so the players name/score doesn't butt against it. 
- Updates the unscore method to remove the **last** score registered for the team instead of the **first**. 
- Updates the player's score.
